### PR TITLE
Bridge rover_lib

### DIFF
--- a/lib/rover_can2/src/rover_can2/constant.hpp
+++ b/lib/rover_can2/src/rover_can2/constant.hpp
@@ -86,7 +86,7 @@ namespace RoverCan2::Constant
         
         ARM_SPEED_CMD,
         ARM_POSITION_STATUS,
-        ARM_JOINT_CONFIG,
+        ARM_JOINT_INFO,
         
         FIX_POSITION,
         FIX_HEADING,

--- a/lib/rover_can2/src/rover_can2/msgs/arm_position_status.hpp
+++ b/lib/rover_can2/src/rover_can2/msgs/arm_position_status.hpp
@@ -1,0 +1,98 @@
+#ifndef ARM_POSITION_STATUS_HPP
+#define ARM_POSITION_STATUS_HPP
+
+#include "rover_can2/msgs/msg.hpp"
+#include "rover_can2/helpers.hpp"
+
+DEFINE_LOG_NODE(ArmPostitionStatus_msg, Logger::eNodeState::OFF)
+
+namespace RoverCan2::Msgs
+{
+
+    class ArmPositionStatus : public Msg<ArmPositionStatus>
+    {
+      public:
+        enum class eMsgContentID : uint8_t
+        {
+            CURRENT_POSITION,
+            eLAST
+        };
+
+      private:
+        struct sMsgData
+        {
+            bool current_position;
+        };
+
+        static constexpr CompileTimeArray<eMsgContentID, TO_UNDERLYING(eMsgContentID::eLAST)> VALID_MSG_IDS
+            = {eMsgContentID::CURRENT_POSITION};
+
+        sMsgData _data;
+
+      public:
+        ArmPositionStatus():
+            Msg(Constant::eMsgId::ARM_POSITION_STATUS)
+        {
+            _data.current_position = false;
+        }
+
+        eLoadMsgCode _loadMsg(const CanMsg& msg_)
+        {
+            if (msg_.getMsgID() == Constant::eMsgId::INVALID)
+            {
+                return eLoadMsgCode::ERROR_INVALID_MSG;
+            }
+            if (msg_.getMsgID() != this->getMsgId())
+            {
+                return eLoadMsgCode::NOT_CONCERNED;
+            }
+
+            eMsgContentID contentId = static_cast<eMsgContentID>(msg_.getMsgContentID());
+            if (!VALID_MSG_IDS.contains(contentId))
+            {
+                LOG_DEBUG(Logger::Nodes::ArmPostitionStatus_msg,
+                          "Unexpected msgContentId: %u (expected < %u)",
+                          TO_UNDERLYING(contentId),
+                          TO_UNDERLYING(eMsgContentID::eLAST));
+                return eLoadMsgCode::ERROR_MISMATCH;
+            }
+
+            bool success = Helpers::CAN_MSG_TO_ROVER_MSG_CONTENT(msg_, _data.current_position);
+            LOG_DEBUG(Logger::Nodes::ArmPostitionStatus_msg,
+                      "switch (msgContentId) case eMsgContentID::CURRENT_POSITION: %s",
+                      success ? "success" : "failed");
+            if (!success)
+            {
+                return eLoadMsgCode::ERROR_MISMATCH;
+            }
+
+            return Helpers::MSG_CONTENT_IS_LAST_ELEM<eMsgContentID>(msg_) ? eLoadMsgCode::SUCCESS_COMPLETE
+                                                                          : eLoadMsgCode::SUCCESS_INCOMPLETE;
+        }
+
+        std::optional<CanMsg> _getCanMsg(uint8_t msgContentId_) const
+        {
+            eMsgContentID contentId = static_cast<eMsgContentID>(msgContentId_);
+            if (!VALID_MSG_IDS.contains(contentId))
+            {
+                return std::nullopt;
+            }
+            CanMsg msg;
+            Helpers::ROVER_MSG_CONTENT_TO_CAN_MSG(this->getMsgId(), msgContentId_, _data.current_position, msg);
+            return msg;
+        }
+
+        uint8_t _getMsgContentCount() const
+        {
+            return TO_UNDERLYING(eMsgContentID::eLAST);
+        }
+
+        const sMsgData& getData(void) const
+        {
+            return static_cast<const sMsgData&>(_data);
+        }
+    };
+
+}  // namespace RoverCan2::Msgs
+
+#endif  // ARM_INFO_HPP

--- a/lib/rover_can2/src/rover_can2/msgs/arm_speed_cmd.hpp
+++ b/lib/rover_can2/src/rover_can2/msgs/arm_speed_cmd.hpp
@@ -1,0 +1,128 @@
+#ifndef ARM_SPEED_CMD_HPP
+#define ARM_SPEED_CMD_HPP
+
+#include "rover_can2/msgs/msg.hpp"
+#include "rover_can2/helpers.hpp"
+
+DEFINE_LOG_NODE(ArmSpeedCmd_msg, Logger::eNodeState::OFF)
+
+namespace RoverCan2::Msgs
+{
+    class ArmSpeedCmd : public Msg<ArmSpeedCmd>
+    {
+      public:
+        enum class eMsgContentID : uint8_t
+        {
+            TARGET_SPEED,
+            eLAST
+        };
+
+      private:
+        struct sMsgData
+        {
+            float targetSpeed;
+        };
+
+        static constexpr CompileTimeArray<eMsgContentID, TO_UNDERLYING(eMsgContentID::eLAST)> VALID_MSG_IDS
+            = {eMsgContentID::TARGET_SPEED};
+
+        sMsgData _data;
+
+      public:
+        ArmSpeedCmd():
+            Msg(Constant::eMsgId::ARM_SPEED_CMD)
+        {
+            _data.targetSpeed = static_cast<decltype(_data.targetSpeed)>(0);
+        }
+
+        eLoadMsgCode _loadMsg(const CanMsg& msg_)
+        {
+            if (msg_.getMsgID() == Constant::eMsgId::INVALID)
+            {
+                return eLoadMsgCode::ERROR_INVALID_MSG;
+            }
+
+            if (msg_.getMsgID() != this->getMsgId())
+            {
+                return eLoadMsgCode::NOT_CONCERNED;
+            }
+
+            eMsgContentID msgContentId = static_cast<eMsgContentID>(msg_.getMsgContentID());
+            if (!VALID_MSG_IDS.contains(msgContentId))
+            {
+                LOG_DEBUG(Logger::Nodes::ArmSpeedCmd_msg,
+                          "Mismatch between received message and local message definition. Received msgContentId: (%u), "
+                          "expected lower than (%u) and none zero",
+                          TO_UNDERLYING(msgContentId),
+                          TO_UNDERLYING(eMsgContentID::eLAST));
+                return eLoadMsgCode::ERROR_MISMATCH;
+            }
+
+            bool success = false;
+            switch (msgContentId)
+            {
+                case eMsgContentID::TARGET_SPEED:
+                    success = Helpers::CAN_MSG_TO_ROVER_MSG_CONTENT(msg_, _data.targetSpeed);
+                    LOG_DEBUG(Logger::Nodes::ArmSpeedCmd_msg,
+                              "switch (msgContentId) case eMsgContentID::TARGET_SPEED: %s",
+                              success ? "success" : "failed");
+                    break;
+                default:
+                    return eLoadMsgCode::ERROR_IMPLEMENTATION;
+            }
+
+            if (!success)
+            {
+                return eLoadMsgCode::ERROR_MISMATCH;
+            }
+
+            if (Helpers::MSG_CONTENT_IS_LAST_ELEM<eMsgContentID>(msg_))
+            {
+                return eLoadMsgCode::SUCCESS_COMPLETE;
+            }
+            else
+            {
+                return eLoadMsgCode::SUCCESS_INCOMPLETE;
+            }
+        }
+
+        std::optional<CanMsg> _getCanMsg(const uint8_t msgContentId_) const
+        {
+            eMsgContentID msgContentID = static_cast<eMsgContentID>(msgContentId_);
+
+            if (!VALID_MSG_IDS.contains(msgContentID))
+            {
+                return std::nullopt;
+            }
+
+            CanMsg msg_;
+            switch (static_cast<eMsgContentID>(msgContentId_))
+            {
+                case eMsgContentID::TARGET_SPEED:
+                    Helpers::ROVER_MSG_CONTENT_TO_CAN_MSG(this->getMsgId(), msgContentId_, _data.targetSpeed, msg_);
+                    break;
+
+                case eMsgContentID::eLAST:
+                    return std::nullopt;
+            }
+
+            return msg_;
+        }
+        uint8_t _getMsgContentCount(void) const
+        {
+            return TO_UNDERLYING(eMsgContentID::eLAST);
+        }
+
+        sMsgData& data(void)
+        {
+            return _data;
+        }
+
+        const sMsgData& getData(void) const
+        {
+            return static_cast<const sMsgData&>(_data);
+        }
+    };
+}  // namespace RoverCan2::Msgs
+
+#endif


### PR DESCRIPTION
This pull request introduces changes to the `RoverCan2` module to enhance message handling for arm-related commands and statuses. The key updates include renaming a constant for clarity and adding new message classes for `ArmPositionStatus` and `ArmSpeedCmd`.

### Updates to constants:
* Renamed `ARM_JOINT_CONFIG` to `ARM_JOINT_INFO` in `namespace RoverCan2::Constant` for improved clarity and consistency. (`lib/rover_can2/src/rover_can2/constant.hpp`, [lib/rover_can2/src/rover_can2/constant.hppL89-R89](diffhunk://#diff-5cbb80ba9f7875945c74fc1ede10b6a6e86f0ecb29cbd9219cba42988bcda45eL89-R89))

### New message classes:
* Added a new class `ArmPositionStatus` to handle messages related to the arm's current position. This includes methods for loading and generating CAN messages, as well as validation of message content IDs. (`lib/rover_can2/src/rover_can2/msgs/arm_position_status.hpp`, [lib/rover_can2/src/rover_can2/msgs/arm_position_status.hppR1-R98](diffhunk://#diff-d40ac5a7907a65dee98345503bfbc97c89004d7bc1dcc71347dbec2e284eaea6R1-R98))
* Added a new class `ArmSpeedCmd` to manage messages for arm speed commands. This class supports message parsing, validation, and generation, with a focus on target speed handling. (`lib/rover_can2/src/rover_can2/msgs/arm_speed_cmd.hpp`, [lib/rover_can2/src/rover_can2/msgs/arm_speed_cmd.hppR1-R128](diffhunk://#diff-d9653f3e315e2216a9450d1778a42a03631166407d6bc34545b1125b319de455R1-R128))